### PR TITLE
fix: update SPA fallback route in server.js to use '/*' for compatibi…

### DIFF
--- a/aws-ec2/dockerfiles/server.js
+++ b/aws-ec2/dockerfiles/server.js
@@ -39,8 +39,8 @@ app.use('/api', createProxyMiddleware({
   },
 }));
 
-// SPA fallback
-app.get('*', (_req, res) => {
+// SPA fallback (Express 5 / path-to-regexp: use '/*' instead of '*')
+app.get('/*', (_req, res) => {
   res.sendFile(path.join(distDir, 'index.html'));
 });
 


### PR DESCRIPTION
…lity with Express 5 and path-to-regexp